### PR TITLE
Improve delete error messages

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -49,4 +49,4 @@ Contains the GraphQL schema definitions and resolvers.
 11. Run `docker-compose up --build` in a separate screen.
 12. After the images have been built, run `docker exec -it server_db_1 bash`.
 13. Login to the mysql server using `mysql -u root -p` and key in your password previously set in `.env`.
-14. Run `CREATE DATABASE anime` and perform the relevant SQL migrations as laid out in each README.md in the `./prisma/migrations/` folder.
+14. Run `CREATE DATABASE anime` and perform the relevant SQL migrations as laid out in each README.md and the `custom_migrations.sql` in the `./prisma/` folder.

--- a/server/prisma/custom_migrations.sql
+++ b/server/prisma/custom_migrations.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `anime`.`AlternativeTitle` DROP FOREIGN KEY `AlternativeTitle_ibfk_1`;
+
+ALTER TABLE `anime`.`AlternativeTitle` DROP FOREIGN KEY `AlternativeTitle_ibfk_2`;
+
+ALTER TABLE `anime`.`AlternativeTitle` ADD FOREIGN KEY (`episodeId`) REFERENCES `anime`.`Episode`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `anime`.`AlternativeTitle` ADD FOREIGN KEY (`seriesId`) REFERENCES `anime`.`Series`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/src/resolvers/Mutation/Episode.ts
+++ b/server/src/resolvers/Mutation/Episode.ts
@@ -53,6 +53,16 @@ export const Episode = {
     ctx: Context,
     _info: unknown
   ): Promise<EpisodeType> {
-    return await ctx.prisma.episode.delete(args);
+    try {
+      return await ctx.prisma.episode.delete(args);
+    } catch (error) {
+      const message: string = error.message;
+      if (message.includes('`File`')) {
+        throw new Error(
+          `Please remove all associated files before deleting the episode.`
+        );
+      }
+      throw error;
+    }
   },
 };


### PR DESCRIPTION
Adds custom migrations for changing the behaviour of `AlternativeTitle` foreign keys to `CASCADE ON DELETE`.

Also introduces some improved error messages for deleting series and episodes with related episodes and files respectively.

Implemented temporary workaround for Prisma's failure to properly carry out a delete with cascade if the referencing field is non nullable.

Also adds in a better error message for colliding usernames.