### PR TITLE
Improve AG Grid rendering height

### DIFF
--- a/client/src/Navigation/index.tsx
+++ b/client/src/Navigation/index.tsx
@@ -114,6 +114,7 @@ const Navigation = (props: any) => {
   const [innerWidth, setInnerWidth] = useState<number>(window.innerWidth);
   const [mobileOpen, setMobileOpen] = useState<boolean>(false);
   const [expanded, setExpanded] = useState<boolean>(window.innerWidth > 1366);
+  const [minHeight, setMinHeight] = useState<number>(window.innerWidth > 600 ? window.innerHeight - 112 : window.innerHeight - 104)
 
   const { data: AuthData } = useLoggedInQuery({
     fetchPolicy: 'cache-and-network',
@@ -122,6 +123,7 @@ const Navigation = (props: any) => {
   useEffect(() => {
     const handleResize = () => {
       setInnerWidth(window.innerWidth);
+      setMinHeight(window.innerWidth > 600 ? window.innerHeight - 112 : window.innerHeight - 104);
       setExpanded(window.innerWidth >= 1366);
     };
     window.addEventListener('resize', handleResize);
@@ -305,7 +307,7 @@ const Navigation = (props: any) => {
       </Drawer>
       <div className={classes.contentWrapper}>
         <div className={classes.toolbar} />
-        <main className={classes.content}>
+        <main className={classes.content} style={{ minHeight: minHeight }}>
           {props.children}
         </main>
       </div>

--- a/client/src/Navigation/index.tsx
+++ b/client/src/Navigation/index.tsx
@@ -9,7 +9,7 @@ import {
   ListItemIcon,
   ListItemText,
   Toolbar,
-  Typography,
+  Typography
 } from '@material-ui/core';
 import { grey } from '@material-ui/core/colors';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
@@ -92,6 +92,9 @@ const useStyles = makeStyles((theme: Theme) =>
       color: grey[100],
     },
     toolbar: theme.mixins.toolbar,
+    contentWrapper: {
+      flexGrow: 1,
+    },
     content: {
       flexGrow: 1,
       backgroundColor: theme.palette.background.default,
@@ -291,8 +294,8 @@ const Navigation = (props: any) => {
             {expanded ? (
               <ChevronLeftOutlinedIcon />
             ) : (
-              <ChevronRightOutlinedIcon />
-            )}
+                <ChevronRightOutlinedIcon />
+              )}
           </ListItemIcon>
           <ListItemText
             primary={'Collapse Sidebar'}
@@ -300,10 +303,12 @@ const Navigation = (props: any) => {
           />
         </ListItem>
       </Drawer>
-      <main className={classes.content}>
+      <div className={classes.contentWrapper}>
         <div className={classes.toolbar} />
-        {props.children}
-      </main>
+        <main className={classes.content}>
+          {props.children}
+        </main>
+      </div>
     </div>
   );
 };

--- a/client/src/Tables/EpisodesTable.tsx
+++ b/client/src/Tables/EpisodesTable.tsx
@@ -6,7 +6,7 @@ import {
   makeStyles,
   Paper,
   Theme,
-  Typography,
+  Typography
 } from '@material-ui/core';
 import { blueGrey } from '@material-ui/core/colors';
 import AddIcon from '@material-ui/icons/Add';
@@ -35,9 +35,6 @@ const useStyles = makeStyles((theme: Theme) =>
     paper: {
       padding: theme.spacing(3),
       textAlign: 'center',
-    },
-    tableHeader: {
-      marginBottom: '5px',
     },
     tableTitle: {
       color: blueGrey[700],
@@ -79,9 +76,9 @@ export const EpisodesTable = (props: Props) => {
   const history = useHistory();
   const [gridApi, setGridApi] = useState<
     | {
-        api: GridApi;
-        columnApi: ColumnApi;
-      }
+      api: GridApi;
+      columnApi: ColumnApi;
+    }
     | undefined
   >(undefined);
   const [showForm, setShowForm] = useState<boolean>(false);
@@ -154,13 +151,12 @@ export const EpisodesTable = (props: Props) => {
   return (
     <div>
       <Paper elevation={3} className={classes.paper}>
-        <Grid container spacing={3} className={classes.tableHeader}>
-          <Grid item xs={12}>
-            <Grid container spacing={3}>
-              <Grid item xs={12} sm className={classes.tableTitle}>
-                <Typography variant="h5">Episodes</Typography>
-              </Grid>
-              {AuthData?.loggedIn?.role &&
+        <Grid container direction={'column'} spacing={3}>
+          <Grid item container spacing={3}>
+            <Grid item xs={12} sm className={classes.tableTitle}>
+              <Typography variant="h5">Episodes</Typography>
+            </Grid>
+            {AuthData?.loggedIn?.role &&
               writeAccess.includes(AuthData.loggedIn.role) ? (
                 <>
                   <Grid item xs={12} sm={'auto'}>
@@ -229,7 +225,6 @@ export const EpisodesTable = (props: Props) => {
                   </Button>
                 </Grid>
               )}
-            </Grid>
           </Grid>
           <Grid item xs={12}>
             <div className="ag-theme-material" style={{ height: '500px' }}>

--- a/client/src/Tables/EpisodesTable.tsx
+++ b/client/src/Tables/EpisodesTable.tsx
@@ -85,6 +85,8 @@ export const EpisodesTable = (props: Props) => {
   const [showBatchForm, setShowBatchForm] = useState<boolean>(false);
   const [formAction, setFormAction] = useState<ActionType>(ActionType.CREATE);
   const [selectedRows, setSelectedRows] = useState<Episode[]>([]);
+  const [innerWidth, setInnerWidth] = useState<number>(window.innerWidth)
+  const [maxGridHeight, setMaxGridHeight] = useState<number>(window.innerWidth > 600 ? window.innerHeight - 160 : window.innerHeight - 152)
 
   const { data: rowData, refetch } = useEpisodesInSeriesQuery({
     fetchPolicy: 'cache-and-network',
@@ -120,6 +122,15 @@ export const EpisodesTable = (props: Props) => {
     return () => window.removeEventListener('resize', hideColumnsMobile);
   }, [hideColumnsMobile]);
 
+  useEffect(() => {
+    const handleResize = () => {
+      setInnerWidth(window.innerWidth);
+      setMaxGridHeight(window.innerWidth > 600 ? window.innerHeight - 160 : window.innerHeight - 152);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [])
+
   const gridOptions = {
     enableCellTextSelection: true,
   };
@@ -150,9 +161,9 @@ export const EpisodesTable = (props: Props) => {
 
   return (
     <div>
-      <Paper elevation={3} className={classes.paper}>
-        <Grid container direction={'column'} spacing={3}>
-          <Grid item container spacing={3}>
+      <Paper elevation={3} className={classes.paper} style={{ height: maxGridHeight, maxHeight: innerWidth > 600 ? 560 : 676 }} >
+        <Grid container direction={'column'} spacing={3} style={{ height: maxGridHeight - 48, maxHeight: 'calc(100% + 24px)' }}>
+          <Grid container item spacing={3}>
             <Grid item xs={12} sm className={classes.tableTitle}>
               <Typography variant="h5">Episodes</Typography>
             </Grid>
@@ -226,8 +237,8 @@ export const EpisodesTable = (props: Props) => {
                 </Grid>
               )}
           </Grid>
-          <Grid item xs={12}>
-            <div className="ag-theme-material" style={{ height: '500px' }}>
+          <Grid item xs>
+            <div className="ag-theme-material" style={{ height: '100%' }}>
               <AgGridReact
                 onGridReady={onGridReady}
                 animateRows
@@ -238,7 +249,7 @@ export const EpisodesTable = (props: Props) => {
                 gridOptions={gridOptions}
                 columnDefs={columnDefs}
                 rowData={(rowData?.episodesInSeries as any[]) || []}
-              ></AgGridReact>
+              />
             </div>
           </Grid>
         </Grid>

--- a/client/src/Tables/SeriesTable.tsx
+++ b/client/src/Tables/SeriesTable.tsx
@@ -5,7 +5,7 @@ import {
   makeStyles,
   Paper,
   Theme,
-  Typography,
+  Typography
 } from '@material-ui/core';
 import { blueGrey } from '@material-ui/core/colors';
 import AddOutlinedIcon from '@material-ui/icons/AddOutlined';
@@ -29,6 +29,10 @@ const useStyles = makeStyles((theme: Theme) =>
     paper: {
       padding: theme.spacing(3),
       textAlign: 'center',
+      height: 'calc(100% - 36px)'
+    },
+    mainGrid: {
+      height: 'calc(100% + 24px)'
     },
     tableHeader: {
       marginBottom: '5px',
@@ -92,8 +96,8 @@ const columnDefs = [
     valueGetter: (params: { data: Series }) => {
       return params.data.releaseSeason && params.data.releaseYear
         ? `${renderSeason(params.data.releaseSeason)} ${moment(
-            params.data.releaseYear
-          ).format('YYYY')}`
+          params.data.releaseYear
+        ).format('YYYY')}`
         : '';
     },
     width: 180,
@@ -132,9 +136,9 @@ export const SeriesTable = () => {
   const history = useHistory();
   const [gridApi, setGridApi] = useState<
     | {
-        api: GridApi;
-        columnApi: ColumnApi;
-      }
+      api: GridApi;
+      columnApi: ColumnApi;
+    }
     | undefined
   >(undefined);
   const [showForm, setShowForm] = useState<boolean>(false);
@@ -265,15 +269,14 @@ export const SeriesTable = () => {
   }, [hideColumnsMobile]);
 
   return (
-    <div>
+    <div style={{ height: '100%' }}>
       <Paper elevation={3} className={classes.paper}>
-        <Grid container spacing={3} className={classes.tableHeader}>
-          <Grid item xs={12}>
-            <Grid container spacing={3}>
-              <Grid item xs={12} sm className={classes.tableTitle}>
-                <Typography variant="h5">All Series</Typography>
-              </Grid>
-              {AuthData?.loggedIn?.role &&
+        <Grid container direction={'column'} spacing={3} className={classes.mainGrid}>
+          <Grid container item spacing={3} className={classes.tableHeader}>
+            <Grid item xs={12} sm className={classes.tableTitle}>
+              <Typography variant="h5">Catalog</Typography>
+            </Grid>
+            {AuthData?.loggedIn?.role &&
               writeAccess.includes(AuthData.loggedIn.role) ? (
                 <>
                   <Grid item xs={6} sm={'auto'}>
@@ -319,10 +322,9 @@ export const SeriesTable = () => {
                   </Button>
                 </Grid>
               )}
-            </Grid>
           </Grid>
-          <Grid item xs={12}>
-            <div className="ag-theme-material" style={{ height: '500px' }}>
+          <Grid item xs>
+            <div className="ag-theme-material" style={{ height: '100%' }}>
               <AgGridReact
                 onGridReady={onGridReady}
                 animateRows
@@ -333,24 +335,26 @@ export const SeriesTable = () => {
                 gridOptions={gridOptions}
                 columnDefs={columnDefs}
                 rowData={(rowData?.allSeries as any[]) || []}
-              ></AgGridReact>
+              />
             </div>
           </Grid>
         </Grid>
       </Paper>
-      {showForm && (
-        <SeriesForm
-          open={showForm}
-          action={formAction}
-          onSubmit={() => {
-            refetch();
-            setFormAction(ActionType.CREATE);
-          }}
-          onClose={() => {
-            setShowForm(false);
-          }}
-        />
-      )}
-    </div>
+      {
+        showForm && (
+          <SeriesForm
+            open={showForm}
+            action={formAction}
+            onSubmit={() => {
+              refetch();
+              setFormAction(ActionType.CREATE);
+            }}
+            onClose={() => {
+              setShowForm(false);
+            }}
+          />
+        )
+      }
+    </div >
   );
 };

--- a/client/src/Tables/SeriesTable.tsx
+++ b/client/src/Tables/SeriesTable.tsx
@@ -34,9 +34,6 @@ const useStyles = makeStyles((theme: Theme) =>
     mainGrid: {
       height: 'calc(100% + 24px)'
     },
-    tableHeader: {
-      marginBottom: '5px',
-    },
     tableTitle: {
       color: blueGrey[700],
       textAlign: 'left',
@@ -272,7 +269,7 @@ export const SeriesTable = () => {
     <div style={{ height: '100%' }}>
       <Paper elevation={3} className={classes.paper}>
         <Grid container direction={'column'} spacing={3} className={classes.mainGrid}>
-          <Grid container item spacing={3} className={classes.tableHeader}>
+          <Grid container item spacing={3}>
             <Grid item xs={12} sm className={classes.tableTitle}>
               <Typography variant="h5">Catalog</Typography>
             </Grid>

--- a/client/src/Tables/UsersTable.tsx
+++ b/client/src/Tables/UsersTable.tsx
@@ -31,9 +31,6 @@ const useStyles = makeStyles((theme: Theme) =>
     mainGrid: {
       height: 'calc(100% + 24px)'
     },
-    tableHeader: {
-      marginBottom: '5px',
-    },
     tableTitle: {
       color: blueGrey[700],
       textAlign: 'left',
@@ -167,7 +164,7 @@ export const UsersTable = () => {
     <div style={{ height: '100%' }}>
       <Paper elevation={3} className={classes.paper}>
         <Grid container direction={'column'} spacing={3} className={classes.mainGrid}>
-          <Grid container item spacing={3} className={classes.tableHeader}>
+          <Grid container item spacing={3}>
             <Grid item xs={12} sm className={classes.tableTitle}>
               <Typography variant="h5">Users</Typography>
             </Grid>

--- a/client/src/Tables/UsersTable.tsx
+++ b/client/src/Tables/UsersTable.tsx
@@ -5,7 +5,7 @@ import {
   makeStyles,
   Paper,
   Theme,
-  Typography,
+  Typography
 } from '@material-ui/core';
 import { blueGrey } from '@material-ui/core/colors';
 import AddOutlinedIcon from '@material-ui/icons/AddOutlined';
@@ -26,6 +26,10 @@ const useStyles = makeStyles((theme: Theme) =>
     paper: {
       padding: theme.spacing(3),
       textAlign: 'center',
+      height: 'calc(100% - 36px)'
+    },
+    mainGrid: {
+      height: 'calc(100% + 24px)'
     },
     tableHeader: {
       marginBottom: '5px',
@@ -80,9 +84,9 @@ export const UsersTable = () => {
   const classes = useStyles();
   const [gridApi, setGridApi] = useState<
     | {
-        api: GridApi;
-        columnApi: ColumnApi;
-      }
+      api: GridApi;
+      columnApi: ColumnApi;
+    }
     | undefined
   >(undefined);
   const [showForm, setShowForm] = useState<boolean>(false);
@@ -160,46 +164,44 @@ export const UsersTable = () => {
   }, [hideColumnsMobile]);
 
   return (
-    <div>
+    <div style={{ height: '100%' }}>
       <Paper elevation={3} className={classes.paper}>
-        <Grid container spacing={3} className={classes.tableHeader}>
-          <Grid item xs={12}>
-            <Grid container spacing={3}>
-              <Grid item xs={12} sm className={classes.tableTitle}>
-                <Typography variant="h5">Users</Typography>
-              </Grid>
-              <Grid item xs={6} sm={'auto'}>
-                <Button
-                  fullWidth
-                  startIcon={<AddOutlinedIcon />}
-                  variant="contained"
-                  color="primary"
-                  onClick={() => {
-                    setFormAction(ActionType.CREATE);
-                    setShowForm(true);
-                  }}
-                >
-                  Add
+        <Grid container direction={'column'} spacing={3} className={classes.mainGrid}>
+          <Grid container item spacing={3} className={classes.tableHeader}>
+            <Grid item xs={12} sm className={classes.tableTitle}>
+              <Typography variant="h5">Users</Typography>
+            </Grid>
+            <Grid item xs={6} sm={'auto'}>
+              <Button
+                fullWidth
+                startIcon={<AddOutlinedIcon />}
+                variant="contained"
+                color="primary"
+                onClick={() => {
+                  setFormAction(ActionType.CREATE);
+                  setShowForm(true);
+                }}
+              >
+                Add
                 </Button>
-              </Grid>
-              <Grid item xs={6} sm={'auto'}>
-                <Button
-                  fullWidth
-                  startIcon={<EditOutlinedIcon />}
-                  disabled={selectedRows.length !== 1}
-                  variant="contained"
-                  onClick={() => {
-                    setFormAction(ActionType.UPDATE);
-                    setShowForm(true);
-                  }}
-                >
-                  Edit
+            </Grid>
+            <Grid item xs={6} sm={'auto'}>
+              <Button
+                fullWidth
+                startIcon={<EditOutlinedIcon />}
+                disabled={selectedRows.length !== 1}
+                variant="contained"
+                onClick={() => {
+                  setFormAction(ActionType.UPDATE);
+                  setShowForm(true);
+                }}
+              >
+                Edit
                 </Button>
-              </Grid>
             </Grid>
           </Grid>
-          <Grid item xs={12}>
-            <div className="ag-theme-material" style={{ height: '500px' }}>
+          <Grid item xs>
+            <div className="ag-theme-material" style={{ height: "100%" }}>
               <AgGridReact
                 onGridReady={onGridReady}
                 animateRows
@@ -210,7 +212,7 @@ export const UsersTable = () => {
                 gridOptions={gridOptions}
                 columnDefs={columnDefs}
                 rowData={(rowData?.users as any[]) || []}
-              ></AgGridReact>
+              />
             </div>
           </Grid>
         </Grid>

--- a/client/src/pages/CatalogPage/index.tsx
+++ b/client/src/pages/CatalogPage/index.tsx
@@ -1,23 +1,32 @@
 import { createStyles, Grid, makeStyles, Theme } from '@material-ui/core';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { withAuth } from '../../HOC/withAuth';
 import { SeriesTable } from '../../Tables/SeriesTable';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    root: {
-      flexGrow: 1,
+    pageGrid: {
+      height: "100%"
     },
   })
 );
 
 const CatalogPage = () => {
   const classes = useStyles();
+  const [fullHeight, setFullHeight] = useState<number>(window.innerWidth > 600 ? window.innerHeight - 100 : window.innerHeight - 92)
+
+  useEffect(() => {
+    const handleResize = () => {
+      setFullHeight(window.innerWidth > 600 ? window.innerHeight - 100 : window.innerHeight - 92);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [])
 
   return (
-    <div className={classes.root}>
-      <Grid container spacing={3}>
-        <Grid item xs={12}>
+    <div style={{ height: fullHeight }}>
+      <Grid container spacing={3} className={classes.pageGrid}>
+        <Grid item xs={12} className={classes.pageGrid}>
           <SeriesTable />
         </Grid>
       </Grid>

--- a/client/src/pages/SearchPage/index.tsx
+++ b/client/src/pages/SearchPage/index.tsx
@@ -6,7 +6,7 @@ import {
   Paper,
   TextField,
   Theme,
-  Typography,
+  Typography
 } from '@material-ui/core';
 import { blueGrey } from '@material-ui/core/colors';
 import PageviewOutlinedIcon from '@material-ui/icons/PageviewOutlined';
@@ -28,12 +28,16 @@ type Result = {
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
+    pageGrid: {
+      height: "100%"
+    },
     paper: {
       padding: theme.spacing(3),
       textAlign: 'center',
+      height: 'calc(100% - 36px)'
     },
-    tableHeader: {
-      marginBottom: '5px',
+    mainGrid: {
+      height: 'calc(100% + 24px)'
     },
     tableTitle: {
       color: blueGrey[700],
@@ -67,14 +71,15 @@ const gridOptions = {
 const SearchPage = () => {
   const classes = useStyles();
   const history = useHistory();
+  const [fullHeight, setFullHeight] = useState<number>(window.innerWidth > 600 ? window.innerHeight - 100 : window.innerHeight - 92)
   const [contains, setContains] = useState<string>('');
   const [results, setResults] = useState<Result[]>([]);
   const [selectedRows, setSelectedRows] = useState<Result[]>([]);
   const [gridApi, setGridApi] = useState<
     | {
-        api: GridApi;
-        columnApi: ColumnApi;
-      }
+      api: GridApi;
+      columnApi: ColumnApi;
+    }
     | undefined
   >(undefined);
 
@@ -114,6 +119,14 @@ const SearchPage = () => {
       }
     }
   }, [gridApi]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setFullHeight(window.innerWidth > 600 ? window.innerHeight - 112 : window.innerHeight - 104);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [])
 
   useEffect(() => {
     window.addEventListener('resize', hideColumnsMobile);
@@ -156,61 +169,65 @@ const SearchPage = () => {
   };
 
   return (
-    <div>
-      <Paper elevation={3} className={classes.paper}>
-        <Grid container spacing={3} className={classes.tableHeader}>
-          <Grid item xs={12}>
-            <Grid container spacing={3}>
-              <Grid item xs={12} sm className={classes.tableTitle}>
-                <Typography variant="h5">Quick Search</Typography>
+    <div style={{ height: fullHeight }}>
+      <Grid container spacing={3} className={classes.pageGrid}>
+        <Grid item xs={12} className={classes.pageGrid}>
+          <Paper elevation={3} className={classes.paper}>
+            <Grid container direction={'column'} spacing={3} className={classes.mainGrid}>
+              <Grid container item spacing={3}>
+                <Grid item xs={12} sm className={classes.tableTitle}>
+                  <Typography variant="h5">Quick Search</Typography>
+                </Grid>
+                <Grid item xs={12} sm={'auto'}>
+                  <Button
+                    fullWidth
+                    startIcon={<PageviewOutlinedIcon />}
+                    disabled={selectedRows.length !== 1}
+                    variant="contained"
+                    onClick={() => {
+                      viewSelected();
+                    }}
+                  >
+                    View
+              </Button>
+                </Grid>
+                <Grid item xs={12} container spacing={3}>
+                  <Grid
+                    item
+                    xs={12}
+                    sm={8}
+                    md={4}
+                    style={{ textAlign: 'left' }}
+                  >
+                    <TextField
+                      variant="outlined"
+                      value={contains}
+                      placeholder={'Search'}
+                      onChange={(event) => setContains(event.target.value)}
+                      fullWidth
+                    />
+                  </Grid>
+                </Grid>
               </Grid>
-              <Grid item xs={12} sm={'auto'}>
-                <Button
-                  fullWidth
-                  startIcon={<PageviewOutlinedIcon />}
-                  disabled={selectedRows.length !== 1}
-                  variant="contained"
-                  onClick={() => {
-                    viewSelected();
-                  }}
-                >
-                  View
-                </Button>
+              <Grid item xs>
+                <div className="ag-theme-material" style={{ height: '100%' }}>
+                  <AgGridReact
+                    onGridReady={onGridReady}
+                    animateRows
+                    enableCellTextSelection
+                    rowDeselection
+                    rowSelection="single"
+                    gridOptions={gridOptions}
+                    columnDefs={columnDefs}
+                    onSelectionChanged={onSelectionChanged}
+                    rowData={(results as Result[]) || []}
+                  />
+                </div>
               </Grid>
             </Grid>
-          </Grid>
-          <Grid
-            item
-            xs={12}
-            sm={8}
-            md={4}
-            style={{ textAlign: 'left', marginBottom: '10px' }}
-          >
-            <TextField
-              variant="outlined"
-              value={contains}
-              placeholder={'Search'}
-              onChange={(event) => setContains(event.target.value)}
-              fullWidth
-            />
-          </Grid>
+          </Paper>
         </Grid>
-        <Grid item xs={12}>
-          <div className="ag-theme-material" style={{ height: '500px' }}>
-            <AgGridReact
-              onGridReady={onGridReady}
-              animateRows
-              enableCellTextSelection
-              rowDeselection
-              rowSelection="single"
-              gridOptions={gridOptions}
-              columnDefs={columnDefs}
-              onSelectionChanged={onSelectionChanged}
-              rowData={(results as Result[]) || []}
-            ></AgGridReact>
-          </div>
-        </Grid>
-      </Paper>
+      </Grid>
     </div>
   );
 };

--- a/client/src/pages/UsersPage/index.tsx
+++ b/client/src/pages/UsersPage/index.tsx
@@ -1,14 +1,33 @@
-import { Grid } from '@material-ui/core';
-import React from 'react';
+import { createStyles, Grid, makeStyles, Theme } from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
 import { Role } from '../../gql/documents';
 import { withAuth } from '../../HOC/withAuth';
 import { UsersTable } from '../../Tables/UsersTable';
 
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    pageGrid: {
+      height: "100%"
+    },
+  })
+);
+
 const UsersPage = () => {
+  const classes = useStyles();
+  const [fullHeight, setFullHeight] = useState<number>(window.innerWidth > 600 ? window.innerHeight - 100 : window.innerHeight - 92)
+
+  useEffect(() => {
+    const handleResize = () => {
+      setFullHeight(window.innerWidth > 600 ? window.innerHeight - 100 : window.innerHeight - 92);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [])
+
   return (
-    <div>
-      <Grid container spacing={3}>
-        <Grid item xs={12}>
+    <div style={{ height: fullHeight }}>
+      <Grid container spacing={3} className={classes.pageGrid}>
+        <Grid item xs={12} className={classes.pageGrid}>
           <UsersTable />
         </Grid>
       </Grid>


### PR DESCRIPTION
Formats AG Grid to take up full height of webpage.

Episode table expands to a maximum of 500px.

![image](https://user-images.githubusercontent.com/1428635/89247508-13ffbe80-d640-11ea-96a6-b7dba40838c3.png)

![image](https://user-images.githubusercontent.com/1428635/89247485-04807580-d640-11ea-91cf-d5eb1433cc8e.png)
