### PR TITLE
Order the return of queries with episodes based on episode number

### DIFF
--- a/server/src/resolvers/Query/Episode.ts
+++ b/server/src/resolvers/Query/Episode.ts
@@ -19,7 +19,11 @@ export const Episode = {
     _args: unknown,
     ctx: Context
   ): Promise<EpisodeType[]> {
-    return await ctx.prisma.episode.findMany();
+    return await ctx.prisma.episode.findMany({
+      orderBy: {
+        episodeNumber: 'asc',
+      },
+    });
   },
 
   async episodesInSeries(

--- a/server/src/resolvers/Reducers/Series.ts
+++ b/server/src/resolvers/Reducers/Series.ts
@@ -30,6 +30,9 @@ export const Series = {
       where: {
         seriesId: parent.id,
       },
+      orderBy: {
+        episodeNumber: 'asc',
+      },
     });
   },
 


### PR DESCRIPTION
Queries involving episodes have been updated to order the result by episode number.